### PR TITLE
Follow-up: avoid model-specific failures in Gemini review workflow

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -59,7 +59,6 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
           gemini_debug: '${{ fromJSON(vars.GEMINI_DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
-          gemini_model: '${{ vars.GEMINI_MODEL }}'
           google_api_key: '${{ secrets.GOOGLE_API_KEY }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'


### PR DESCRIPTION
### Motivation
- The original change cleaned up `mega_orchestrator/modes/sage_router.py` by removing an unused `logging` import and fixing the module docstring to include missing SAGE modes (TERMINAL and FILESYSTEM). 
- CI for the Gemini review workflow can hard-fail when a repository/org `GEMINI_MODEL` value is not available for the account, so the workflow should not force a specific model.

### Description
- Removed the explicit `gemini_model` input from `.github/workflows/gemini-review.yml` so the action can fall back to its default model selection behavior. 
- Kept the earlier code-cleanup in `mega_orchestrator/modes/sage_router.py` which removes the unused `logging` import and updates the module docstring. 
- Committed the change on the branch and created a follow-up PR titled "Follow-up: avoid model-specific failures in Gemini review workflow" to document the fix.

### Testing
- Ran `git diff -- .github/workflows/gemini-review.yml` to review the workflow change and the diff output matched the intended removal of `gemini_model`. 
- Ran `git diff --check` and inspected the workflow snippet with `nl -ba .github/workflows/gemini-review.yml | sed -n '50,75p'` to validate the edit, and these checks succeeded. 
- No repository-level automated tests were run as part of this change; the edits are limited to CI workflow configuration and a one-line code cleanup and therefore were validated via the above repository checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcf808ce48321bf80ed574d69c5bb)