### PR TITLE
🧹 [code health] Remove unused Any and Optional imports in zen_mcp_server_v2.py

### DIFF
--- a/config/zen_mcp_server_v2.py
+++ b/config/zen_mcp_server_v2.py
@@ -5,7 +5,7 @@ import sys
 import subprocess
 import time
 import uuid
-from typing import Dict, List, Any, Optional
+from typing import Dict, List
 
 class ToolRoutingError(Exception):
     """Custom exception for tool routing failures"""


### PR DESCRIPTION
🎯 **What:** Removed unused `Any` and `Optional` imports from `config/zen_mcp_server_v2.py`.
💡 **Why:** Improves code maintainability and readability by cleaning up the namespace and removing dead code.
✅ **Verification:** Verified by compiling the file with `py_compile`, searching for occurrences with `grep`, and running the `pytest` unit test suite.
✨ **Result:** A cleaner, more maintainable codebase with accurate type hinting imports.

---
*PR created automatically by Jules for task [11865160877650821818](https://jules.google.com/task/11865160877650821818) started by @milhy545*