### PR TITLE
🧹 Replace empty except blocks with logging in gmail-mcp utils

### DIFF
--- a/mcp-servers/gmail-mcp/src/email_client/utils.py
+++ b/mcp-servers/gmail-mcp/src/email_client/utils.py
@@ -1,6 +1,9 @@
 import email
+import logging
 from datetime import datetime, timedelta
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 def format_email_summary(msg_data: tuple) -> dict:
     """Format an email message into a summary dict with basic information."""
@@ -65,10 +68,10 @@ def format_email_summary(msg_data: tuple) -> dict:
                 continue
         else: # If loop completes without break
              # Keep original if all formats fail
-             pass
-    except Exception:
+             logger.debug(f"All date formats failed for date string: {date_str}")
+    except Exception as e:
         # Keep original if any other parsing error occurs
-        pass
+        logger.debug(f"Unexpected error parsing date '{date_str}': {e}")
 
     return {
         "id": email_id,


### PR DESCRIPTION
This PR addresses a code health issue where empty except blocks were silencing potential errors during email date parsing in the `gmail-mcp` service.

Changes:
- Added `import logging` and `logger = logging.getLogger(__name__)` to `mcp-servers/gmail-mcp/src/email_client/utils.py`.
- In `format_email_summary`, replaced the `pass` statement in the `for...else` block (triggered when all date formats fail) with a debug log.
- Replaced the `pass` statement in the outer `except Exception` block with a debug log that captures the exception.

These changes improve maintainability and debuggability by providing visibility into why a date might not be parsed, while preserving the existing fallback logic of returning the original date string.

Verification:
- Created a standalone test script that mocks the `mcp` dependency.
- Verified that `format_email_summary` still correctly parses valid dates.
- Verified that it still returns the original string when parsing fails, now with added logging.

---
*PR created automatically by Jules for task [15000127803478205911](https://jules.google.com/task/15000127803478205911) started by @milhy545*